### PR TITLE
fix an issue on a fresh install on EE 1.14. if configuration is saved…

### DIFF
--- a/src/app/code/community/IntegerNet/RemoveCustomerAccountLinks/Model/System/Source/Link.php
+++ b/src/app/code/community/IntegerNet/RemoveCustomerAccountLinks/Model/System/Source/Link.php
@@ -53,7 +53,7 @@ class IntegerNet_RemoveCustomerAccountLinks_Model_System_Source_Link
         /**
          * Fetch all links from customer account navigation block
          */
-        foreach (Mage::app()->getStores() as $store) {
+        foreach (Mage::app()->getStores(true) as $store) {
 
             Mage::app()->setCurrentStore($store->getId());
             Mage::unregister('_singleton/core/design_package');


### PR DESCRIPTION
… and links are removed, the configuration page does not display anymore the list of all links (those enabled and disabled), only those who are enabled. Here the fix provides also the default store (0) to get all links. Problem does not appear on multistore views
